### PR TITLE
82 params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-contracts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Express.js plugin for checking request and response with rho-contracts",
   "license": "BSD-2-Clause",
   "main": "index.js",

--- a/src/middleware.impl.js
+++ b/src/middleware.impl.js
@@ -38,9 +38,13 @@ var extendWithCheckedJson = function (res, responseBodyContract, next) {
 };
 
 var validateRequest = function (req, requestContract, next) {
-    // Check each field (body, query, etc) individually so that we don't
+    // Check each field (body, query, params) individually so that we don't
     // dump the *entire* express req object into the error message.
-    var relevantKeyDescriptions = { body: 'request body', query: 'query string' };
+    var relevantKeyDescriptions = {
+        body: 'request body',
+        query: 'query string',
+        params: 'request params',
+    };
     var key;
     try {
         for (key in relevantKeyDescriptions) {


### PR DESCRIPTION
Not adding this (alongside query) was clearly an oversight. I think adding a test would be require a bit more reworking than I am hoping to do, but I have a test in `api-server` where I need this feature:

https://github.com/bodylabs/api-server/commit/5d8ae443918851d5cb28832b105ff80715c17fc3