### PR TITLE
86 red structured errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,23 @@ Furthermore, note that the middleware works by extending `res` with a method
 thus it is easy to "jump out" of the contract e.g. to send an error.
 
 Finally, there is an asymmetry between the `requestContract`, which is run over
-the whole request (but only `body` and `query` actually checked), and the
-`responseBodyContract`, which is only run over the payload that eventually
-becomes the `res.body`.
+the whole request (but only `body`, `query`, and `params` are actually
+checked), and the `responseBodyContract`, which is only run over the payload
+that eventually becomes the `res.body`.
+
+As of 2.2.0, the exported `ValidationError` says which of the three checked
+fields caused the (first seen) error, under the key `problemField`, e.g.
+```js
+if (err.problemField === 'body') {
+    // do something
+} else if (err.problemField === 'query') {
+    // do something else
+} else if (err.problemField === 'params') {
+    // do yet something else
+} else {
+    // should not happen unless we start checking more fields
+}
+```
 
 
 Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-contracts",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Express.js plugin for checking request and response with rho-contracts",
   "license": "BSD-2-Clause",
   "main": "index.js",

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,7 @@
-var ValidationError = function (message) {
+var ValidationError = function (message, problemField) {
     this.name = 'ValidationError';
     this.message = message;
+    this.problemField = problemField;
     this.stack = (new Error()).stack;
 };
 

--- a/src/middleware.impl.js
+++ b/src/middleware.impl.js
@@ -56,7 +56,7 @@ var validateRequest = function (req, requestContract, next) {
         }
     } catch (e) {
         var prefix = 'Validation error in ' + relevantKeyDescriptions[key] + ':\n';
-        return next(new errors.ValidationError(prefix + e.message));
+        return next(new errors.ValidationError(prefix + e.message, key));
     }
 };
 


### PR DESCRIPTION
Callers (e.g. red api v1) should be able to distinguish errors in request body vs query vs params without parsing the error message.